### PR TITLE
Replaced ownership in the copied oc binary

### DIFF
--- a/ansible-ipi-install/roles/installer/tasks/15_disconnected_registry_create.yml
+++ b/ansible-ipi-install/roles/installer/tasks/15_disconnected_registry_create.yml
@@ -54,8 +54,8 @@
   copy:
     src: /tmp/oc
     dest: "/usr/local/bin/oc"
-    owner: "{{ ansible_user }}"
-    group: "{{ ansible_user }}"
+    owner: "{{ hostvars[groups['registry_host'][0]]['ansible_user'] }}"
+    group: "{{ hostvars[groups['registry_host'][0]]['ansible_user'] }}"
     mode: 0755
   become: yes
   when: groups['registry_host'][0] != groups['provisioner'][0]


### PR DESCRIPTION
This is needed since the task may connect to a registry host with an ansible user different than the provision host.

# Description

In disconnected networks, when copying the oc binary from the provision host to the registry host, it replaces the owner and group from "ansible_user" to "hostvars[groups['registry_host'][0]]['ansible_user']".

The change is needed in case the ansible_user is different in the provision and registry hosts. See below an example of the failure the current version may cause:

https://www.distributed-ci.io/jobs/17108eab-fcc8-4f8a-a530-f891e7d660dc/jobStates?sort=date&task=e7659765-86de-431b-80fa-51c2c5ff70bb

## Type of change

Please select the appropriate options:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change is a documentation update

## Testing

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:

- Versions:
- Hardware:

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [ ] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [ ] A change should not be merged unless it passes CI or there is a comment/update saying what testing was passed.
- [ ] PRs should not be merged unless positively reviewed.
